### PR TITLE
Feature: per-IP rate limiting on login endpoint in api.py

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, jsonify
 from src import auth, validators, database
+from src.utils import is_rate_limited
 
 app = Flask(__name__)
 
@@ -17,6 +18,9 @@ def register():
 
 @app.route("/login", methods=["POST"])
 def login():
+    ip = request.remote_addr
+    if is_rate_limited(ip, max_calls=10, window_seconds=60):
+        return jsonify({"error": "Too many requests"}), 429
     data = request.get_json()
     user = auth.authenticate_user(data["username"], data["password"], database)
     if not user:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,9 @@
 import re
 import time
 import functools
+from collections import defaultdict
+
+_rate_limit_store: dict = defaultdict(list)
 
 
 def retry(times=3, delay=1):
@@ -34,3 +37,13 @@ def sanitize_string(value: str) -> str:
     value = re.sub(r"[\x00-\x1f\x7f]", "", value)
     value = re.sub(r" +", " ", value)
     return value
+
+
+def is_rate_limited(key: str, max_calls: int = 10, window_seconds: int = 60) -> bool:
+    now = time.time()
+    timestamps = _rate_limit_store[key]
+    _rate_limit_store[key] = [t for t in timestamps if now - t < window_seconds]
+    if len(_rate_limit_store[key]) >= max_calls:
+        return True
+    _rate_limit_store[key].append(now)
+    return False


### PR DESCRIPTION
Closes #7

Add sliding-window rate limiter in `utils.py` and apply it to the `/login` route in `api.py`.